### PR TITLE
value bug and quick ui to CardInfo

### DIFF
--- a/resources/js/Components/CardInfo.tsx
+++ b/resources/js/Components/CardInfo.tsx
@@ -14,6 +14,7 @@ import { isPositive } from '@/lib/utils';
 import { Link } from '@inertiajs/react';
 import classNames from 'classnames';
 import { format } from 'date-fns';
+import { FaX } from 'react-icons/fa6';
 import PricesChart from './PricesChart';
 
 interface ICardInfoProps {
@@ -29,16 +30,20 @@ export const CardInfo = ({ card, close, handleDelete }: ICardInfoProps) => {
   const marketPrice = Number(card.prices[0].market || 0);
   const pricePaid = Number(card.pricePaid || 0);
 
+  const value = pricePaid - marketPrice;
+
   return (
     <div className="flex flex-col gap-4 bg-slate-900">
-      <div className="flex-0 mb-2 flex flex-col pb-2">
-        <div className="flex w-full justify-between">
+      <div className="flex-0 mb-2 flex flex-col gap-2 pb-2">
+        <div className="flex w-full justify-between border-b-2 border-b-slate-600">
           <div className="mb-4 flex items-baseline gap-2">
             <span>{cardNumber}</span>
             <h2 className="text-2xl">{card.name}</h2>
             <h3>{cardType}</h3>
           </div>
-          <button onClick={close}>X</button>
+          <button className="text-2xl" onClick={close}>
+            <FaX />
+          </button>
         </div>
         <div className="mb-4 flex justify-between">
           <span>Created at: </span>
@@ -46,17 +51,20 @@ export const CardInfo = ({ card, close, handleDelete }: ICardInfoProps) => {
         </div>
         <div
           className={`mb-4 text-2xl font-bold ${classNames({
-            'text-green-400': isPositive(marketPrice - pricePaid),
-            'text-red-500': !isPositive(marketPrice - pricePaid),
+            'text-green-400': isPositive(value),
+            'text-red-500': !isPositive(value),
           })}`}
         >
-          <span>{isPositive(marketPrice) ? '+' : ''}</span>
-          <span>{marketPrice}</span>
+          <span>{isPositive(value) ? '+' : ''} </span>
+          <span>{value.toFixed(2)}</span>
         </div>
-        <div>{card.pricePaid}</div>
-        <div className="grid grid-cols-3">
-          <img src={card.image} alt={card.name} />
-          <div className="col-span-2">
+        <div className="flex flex-col gap-6 md:grid md:grid-cols-3">
+          <img
+            className="order-2 md:order-1"
+            src={card.image}
+            alt={card.name}
+          />
+          <div className="order-1 md:order-2 md:col-span-2">
             <PricesChart priceChartData={card.prices} />
           </div>
         </div>

--- a/resources/js/Components/PricesChart.tsx
+++ b/resources/js/Components/PricesChart.tsx
@@ -7,7 +7,6 @@ import {
   LineChart,
   ResponsiveContainer,
   XAxis,
-  YAxis,
 } from 'recharts';
 
 interface IPriceChartDataProps {
@@ -23,7 +22,7 @@ export default function PricesChart({ priceChartData }: IPriceChartDataProps) {
           dataKey="created_at"
           tickFormatter={(date) => format(new Date(date), 'MM/dd/yy')} // Format for the date
         />
-        <YAxis label={{ value: 'Value', angle: -90, position: 'insideLeft' }} />
+        {/*<YAxis label={{ value: 'Value', angle: -90, position: 'insideLeft' }} /> */}
         <Legend />
         <Line type="monotone" dataKey="low" stroke="#8884d8" name="Low" />
         <Line type="monotone" dataKey="mid" stroke="#82ca9d" name="Mid" />

--- a/resources/js/Pages/Owned/List.tsx
+++ b/resources/js/Pages/Owned/List.tsx
@@ -1,8 +1,4 @@
 import { IOwned } from '@/all-types';
-import { Head } from '@inertiajs/react';
-import { format } from 'date-fns';
-import { useState } from 'react';
-
 import { CardInfo } from '@/Components/CardInfo';
 import {
   Table,
@@ -12,6 +8,9 @@ import {
   TableHeader,
   TableRow,
 } from '@/Components/ui/table';
+import { Head } from '@inertiajs/react';
+import { format } from 'date-fns';
+import { useState } from 'react';
 
 interface IOwnedListProps {
   cards: IOwned[];


### PR DESCRIPTION
This pull request includes several changes to the `CardInfo` and `PricesChart` components, as well as some import optimizations in the `List` page. The most important changes include the addition of a new icon for the close button, the calculation of the card value, and the removal of the `YAxis` from the `PricesChart`.

Enhancements to `CardInfo` component:

* Added the `FaX` icon from `react-icons` for the close button in `CardInfo` component.
* Introduced a new variable `value` to calculate the difference between `pricePaid` and `marketPrice` in `CardInfo` component.

Changes to `PricesChart` component:

* Removed the `YAxis` from the `PricesChart` component to simplify the chart display.

Import optimizations:

* Reordered and optimized imports in the `List` page to remove unused imports and improve readability. [[1]](diffhunk://#diff-4fc25711a2356cad0a4ef62dbdebcd7200bffffaf71da4d581f38b930f44d59cL2-L5) [[2]](diffhunk://#diff-4fc25711a2356cad0a4ef62dbdebcd7200bffffaf71da4d581f38b930f44d59cR11-R13)