### PR TITLE
Late night value play!

### DIFF
--- a/resources/js/Pages/Owned/Index.tsx
+++ b/resources/js/Pages/Owned/Index.tsx
@@ -1,12 +1,39 @@
 import { IOwned } from '@/all-types';
 import Authenticated from '@/Layouts/AuthenticatedLayout';
+import { isPositive } from '@/lib/utils';
 import { OwnedList } from './List';
 
 export default function OwnedPage(props: { ownedCards: IOwned[] }) {
   const { ownedCards } = props;
 
+  const paid = ownedCards.reduce((acc, card) => {
+    return acc + Number(card.price_paid);
+  }, 0);
+
+  const current = ownedCards.reduce((acc, card) => {
+    return acc + Number(card.prices[card.prices.length - 1].market);
+  }, 0);
+
+  // amout spent vs current value
+  // dashboard vs this page
+
   return (
     <Authenticated>
+      <div className="flex justify-between">
+        <h2>Total Spent: {paid.toFixed(2)}</h2>
+        <h2 className="flex flex-col">
+          <span>Total Value:</span>
+          <span
+            style={{ color: isPositive(current - paid) ? 'green' : 'red' }}
+            className="text-3xl font-extrabold"
+          >
+            {(current - paid).toFixed(2)}
+          </span>
+        </h2>
+        <div>
+          <h3>Current Value: {current.toFixed(2)}</h3>
+        </div>
+      </div>
       <OwnedList cards={ownedCards} />
     </Authenticated>
   );

--- a/resources/js/Pages/Owned/List.tsx
+++ b/resources/js/Pages/Owned/List.tsx
@@ -53,7 +53,10 @@ export function OwnedList({ cards: cardsRaw }: IOwnedListProps) {
 
       <div className="">
         <header className="mb-8 flex justify-between">
-          <div>Owned Cards</div>
+          <div>
+            {/* <div>Total Spent: {totalSpent}</div> */}
+            {/* <div>Total Value: {totalSpent}</div> */}
+          </div>
         </header>
         {currentCard ? (
           <CardInfo


### PR DESCRIPTION
This pull request includes enhancements to the `Owned` page and minor cleanup to the `OwnedList` component in the `resources/js/Pages/Owned` directory. The most important changes include the addition of total spent and current value calculations, as well as the display of these values on the `Owned` page.

Enhancements to the `Owned` page:

* [`resources/js/Pages/Owned/Index.tsx`](diffhunk://#diff-cdd9e23488b6c0af6c995d24da79b7bf171c6725e869fe4d0b9fc79d59033eadR3-R36): Added calculations for total spent and current value of owned cards. Displayed these values on the page with color coding for the difference between current value and total spent.

Cleanup in the `OwnedList` component:

* [`resources/js/Pages/Owned/List.tsx`](diffhunk://#diff-4fc25711a2356cad0a4ef62dbdebcd7200bffffaf71da4d581f38b930f44d59cL56-R59): Commented out unused code related to total spent and total value in the header section.